### PR TITLE
fix: fix android building

### DIFF
--- a/witnesscalc_adapter/src/lib.rs
+++ b/witnesscalc_adapter/src/lib.rs
@@ -278,7 +278,10 @@ fn android() {
             lib_path
         );
         let dest_dir = Path::new(&output_path).join(&env::var("CARGO_NDK_ANDROID_TARGET").unwrap());
-        fs::create_dir_all(&dest_dir).expect("Failed to create output directory");
+        println!("cargo:rerun-if-changed={}", dest_dir.display());
+        if !dest_dir.exists() {
+            fs::create_dir_all(&dest_dir).unwrap();
+        }
         fs::copy(lib_path, Path::new(&dest_dir).join("libc++_shared.so")).unwrap();
     }
 }


### PR DESCRIPTION
- check `ANDROID_NDK` is set
  - see [prerequisites](https://zkmopro.org/docs/prerequisites/#android-configuration)
- check gmp lib is built or not
- link `libc++_shared.so` lib
  - see [cargo-ndk](https://github.com/bbqsrc/cargo-ndk?tab=readme-ov-file#linking-against-and-copying-libc_sharedso-into-the-relevant-places-in-the-output-directory)
  - fix error: if there is no folder, create one