### PR TITLE
feat: add generic witness reader

### DIFF
--- a/witnesscalc_adapter/src/convert_type.rs
+++ b/witnesscalc_adapter/src/convert_type.rs
@@ -4,8 +4,8 @@ use num_bigint::BigInt;
 use num_traits::FromBytes;
 
 pub fn parse_witness_to<T>(
-  buffer: &[u8],
-  from_le_bytes: impl Fn(&[u8]) -> T,
+    buffer: &[u8],
+    from_le_bytes: impl Fn(&[u8]) -> T,
 ) -> io::Result<Vec<T>> {
     /// Prints to the standard ouput only in debug build.
     macro_rules! debug_println {
@@ -15,13 +15,13 @@ pub fn parse_witness_to<T>(
     let mut pos = 0;
 
     // skip format bytes (4 bytes)
-    // ensure that this says "wtns" in ASCII  
-    if &buffer[pos..pos + 4] != b"wtns" {  
-      return Err(io::Error::new(  
-          io::ErrorKind::InvalidData,  
-          "Invalid witness file format.",  
-      ));  
-    }  
+    // ensure that this says "wtns" in ASCII
+    if &buffer[pos..pos + 4] != b"wtns" {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Invalid witness file format.",
+        ));
+    }
     pos += 4;
 
     // read version (4 bytes)
@@ -67,7 +67,7 @@ pub fn parse_witness_to<T>(
 
                 let _n_witness_values =
                     u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
-                    debug_println!("n_witness_values: {}", _n_witness_values);
+                debug_println!("n_witness_values: {}", _n_witness_values);
                 pos += 4;
             }
 
@@ -84,7 +84,7 @@ pub fn parse_witness_to<T>(
             }
             // skip any other section
             _ => {
-                pos = pos + section_length as usize;
+                pos += section_length as usize;
             }
         }
     }

--- a/witnesscalc_adapter/src/convert_type.rs
+++ b/witnesscalc_adapter/src/convert_type.rs
@@ -5,88 +5,99 @@ use num_traits::FromBytes;
 
 pub fn parse_witness_to<T>(
   buffer: &[u8],
-  map_chunk: impl Fn(&[u8]) -> T,
+  from_le_bytes: impl Fn(&[u8]) -> T,
 ) -> io::Result<Vec<T>> {
-  let mut pos = 0;
+    /// Prints to the standard ouput only in debug build.
+    macro_rules! debug_println {
+        ($($arg:tt)*) => (#[cfg(debug_assertions)] println!($($arg)*));
+    }
 
-  // skip format bytes (4 bytes)
-  // this says "wtns" in ASCII
-  pos += 4;
+    let mut pos = 0;
 
-  // read version (4 bytes)
-  let _version = u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
-  // println!("version: {:?}", _version);
-  pos += 4;
+    // skip format bytes (4 bytes)
+    // ensure that this says "wtns" in ASCII  
+    if &buffer[pos..pos + 4] != b"wtns" {  
+      return Err(io::Error::new(  
+          io::ErrorKind::InvalidData,  
+          "Invalid witness file format.",  
+      ));  
+    }  
+    pos += 4;
 
-  // read number of sections (4 bytes)
-  let n_sections = u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
-  // println!("n_sections: {:?}", n_sections);
-  pos += 4;
+    // read version (4 bytes)
+    let _version = u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
+    debug_println!("version: {}", _version);
+    pos += 4;
 
-  // number of 8 bit integers per field element
-  let mut n8 = 0;
+    // read number of sections (4 bytes)
+    let n_sections = u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
+    debug_println!("n_sections: {}", n_sections);
+    pos += 4;
 
-  // iterate through sections to find section_id = 2 (witness data)
-  //
-  // each [section]
-  // - section id (4 bytes)
-  // - section length (8 bytes)
-  for _ in 0..n_sections {
-      let section_id = u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
-      println!("section_id: {:?}", section_id);
-      pos += 4;
+    // number of 8 bit integers per field element
+    let mut n8 = 0;
 
-      let section_length = u64::from_le_bytes(buffer[pos..pos + 8].try_into().unwrap());
-      println!("section_length: {:?}", section_length);
-      pos += 8;
+    // iterate through sections to find section_id = 2 (witness data)
+    //
+    // each [section]
+    // - section id (4 bytes)
+    // - section length (8 bytes)
+    for _ in 0..n_sections {
+        let section_id = u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
+        debug_println!("section_id: {}", section_id);
+        pos += 4;
 
-      match section_id {
-          // [section 1]
-          // - `n8` number of 8 bit integers per field element (4 bytes / u32)
-          // - the field `q` value (32 bytes)
-          // - number of witness values (4 bytes / `u32`)
-          1 => {
-              n8 = u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
-              println!("n8: {:?}", n8);
-              pos += 4;
+        let section_length = u64::from_le_bytes(buffer[pos..pos + 8].try_into().unwrap());
+        debug_println!("section_length: {}", section_length);
+        pos += 8;
 
-              let _q = BigInt::from_signed_bytes_le(&buffer[pos..pos + 32]);
-              println!("q: {:?}", _q);
-              pos += 32;
+        match section_id {
+            // [section 1]
+            // - `n8` number of 8 bit integers per field element (4 bytes / u32)
+            // - the field `q` value (32 bytes)
+            // - number of witness values (4 bytes / `u32`)
+            1 => {
+                n8 = u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
+                debug_println!("n8: {}", n8);
+                pos += 4;
 
-              let _n_witness_values =
-                  u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
-              println!("n_witness_values: {:?}", _n_witness_values);
-              pos += 4;
-          }
+                let _q = BigInt::from_signed_bytes_le(&buffer[pos..pos + 32]);
+                debug_println!("q: {}", _q);
+                pos += 32;
 
-          // [section 2]
-          // - witness data (`n8` bytes per element, section_length bytes total)
-          2 => {
-              // read & convert witness bytes chunk by chunk
-              let elements: Vec<T> = buffer[pos..pos + section_length as usize]
-                  .chunks(usize::try_from(n8).unwrap())
-                  .map(map_chunk)
-                  .collect();
+                let _n_witness_values =
+                    u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
+                    debug_println!("n_witness_values: {}", _n_witness_values);
+                pos += 4;
+            }
 
-              return Ok(elements);
-          }
-          // skip any other section
-          _ => {
-              pos = pos + section_length as usize;
-          }
-      }
-  }
+            // [section 2]
+            // - witness data (`n8` bytes per element, `section_length` bytes total)
+            2 => {
+                // read & convert witness bytes chunk by chunk
+                let elements: Vec<T> = buffer[pos..pos + section_length as usize]
+                    .chunks(usize::try_from(n8).unwrap())
+                    .map(from_le_bytes)
+                    .collect();
 
-  Err(io::Error::new(
-      io::ErrorKind::InvalidData,
-      "Witness section not found.",
-  ))
+                return Ok(elements);
+            }
+            // skip any other section
+            _ => {
+                pos = pos + section_length as usize;
+            }
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "Witness section not found.",
+    ))
 }
 
 #[inline]
 pub fn parse_witness_to_bigints(buffer: &[u8]) -> io::Result<Vec<BigInt>> {
-  parse_witness_to(buffer, BigInt::from_le_bytes)
+    parse_witness_to(buffer, BigInt::from_le_bytes)
 }
 
 pub fn convert_inputs_to_json(inputs: HashMap<String, Vec<String>>) -> String {

--- a/witnesscalc_adapter/src/convert_type.rs
+++ b/witnesscalc_adapter/src/convert_type.rs
@@ -3,66 +3,90 @@ use std::{collections::HashMap, io};
 use num_bigint::BigInt;
 use num_traits::FromBytes;
 
+pub fn parse_witness_to<T>(
+  buffer: &[u8],
+  map_chunk: impl Fn(&[u8]) -> T,
+) -> io::Result<Vec<T>> {
+  let mut pos = 0;
+
+  // skip format bytes (4 bytes)
+  // this says "wtns" in ASCII
+  pos += 4;
+
+  // read version (4 bytes)
+  let _version = u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
+  // println!("version: {:?}", _version);
+  pos += 4;
+
+  // read number of sections (4 bytes)
+  let n_sections = u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
+  // println!("n_sections: {:?}", n_sections);
+  pos += 4;
+
+  // number of 8 bit integers per field element
+  let mut n8 = 0;
+
+  // iterate through sections to find section_id = 2 (witness data)
+  //
+  // each [section]
+  // - section id (4 bytes)
+  // - section length (8 bytes)
+  for _ in 0..n_sections {
+      let section_id = u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
+      println!("section_id: {:?}", section_id);
+      pos += 4;
+
+      let section_length = u64::from_le_bytes(buffer[pos..pos + 8].try_into().unwrap());
+      println!("section_length: {:?}", section_length);
+      pos += 8;
+
+      match section_id {
+          // [section 1]
+          // - `n8` number of 8 bit integers per field element (4 bytes / u32)
+          // - the field `q` value (32 bytes)
+          // - number of witness values (4 bytes / `u32`)
+          1 => {
+              n8 = u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
+              println!("n8: {:?}", n8);
+              pos += 4;
+
+              let _q = BigInt::from_signed_bytes_le(&buffer[pos..pos + 32]);
+              println!("q: {:?}", _q);
+              pos += 32;
+
+              let _n_witness_values =
+                  u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
+              println!("n_witness_values: {:?}", _n_witness_values);
+              pos += 4;
+          }
+
+          // [section 2]
+          // - witness data (`n8` bytes per element, section_length bytes total)
+          2 => {
+              // read & convert witness bytes chunk by chunk
+              let elements: Vec<T> = buffer[pos..pos + section_length as usize]
+                  .chunks(usize::try_from(n8).unwrap())
+                  .map(map_chunk)
+                  .collect();
+
+              return Ok(elements);
+          }
+          // skip any other section
+          _ => {
+              pos = pos + section_length as usize;
+          }
+      }
+  }
+
+  Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "Witness section not found.",
+  ))
+}
+
+#[inline]
 pub fn parse_witness_to_bigints(buffer: &[u8]) -> io::Result<Vec<BigInt>> {
-    let mut pos = 0;
-
-    // Skip the format bytes (4 bytes)
-    pos += 4;
-
-    // Read version (4 bytes)
-    let _version = u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
-    println!("version: {:?}", _version);
-    pos += 4;
-
-    // Read number of sections (4 bytes)
-    let n_sections = u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
-    pos += 4;
-
-    println!("n_sections: {:?}", n_sections);
-
-    // Iterate through sections to find section_id = 2 (witness data)
-    let mut n8 = 0;
-    for _ in 0..n_sections {
-        let section_id = u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
-        println!("section_id: {:?}", section_id);
-        pos += 4;
-
-        let section_length = u64::from_le_bytes(buffer[pos..pos + 8].try_into().unwrap());
-        println!("section_length: {:?}", section_length);
-        pos += 8;
-
-        //for section 1: section id (4 bytes), section length (8 bytes), n8 number of 8 bit integers per field element (4 bytes), the field q value (32 bytes), and the number of witness values (4 bytes)
-        if section_id == 1 {
-            n8 = u32::from_le_bytes(buffer[pos..pos + 4].try_into().unwrap());
-            println!("n8: {:?}", n8);
-            let q = BigInt::from_signed_bytes_le(&buffer[pos + 4..pos + 36]);
-            println!("q: {:?}", q);
-            let n_witness_values =
-                u32::from_le_bytes(buffer[pos + 36..pos + 40].try_into().unwrap());
-            println!("n_witness_values: {:?}", n_witness_values);
-        }
-
-        if section_id == 2 {
-            //count nonzero chunks
-            // Witness data found, read section_length bytes
-            let witness_data = &buffer[pos..pos + section_length as usize];
-
-            // Convert witness data into BigInts (n8 bytes per BigInt)
-            let bigints: Vec<BigInt> = witness_data
-                .chunks(usize::try_from(n8).unwrap())
-                .map(|chunk| BigInt::from_le_bytes(chunk))
-                .collect();
-            return Ok(bigints);
-        } else {
-            // Skip this section
-            pos = pos + section_length as usize;
-        }
-    }
-
-    Err(io::Error::new(
-        io::ErrorKind::InvalidData,
-        "Witness section not found.",
-    ))
+  parse_witness_to(buffer, BigInt::from_le_bytes)
 }
 
 pub fn convert_inputs_to_json(inputs: HashMap<String, Vec<String>>) -> String {

--- a/witnesscalc_adapter/src/lib.rs
+++ b/witnesscalc_adapter/src/lib.rs
@@ -93,7 +93,7 @@ pub fn build_and_link(circuits_dir: &str) {
     if !Path::is_dir(Path::new(circuits_dir)) {
         panic!("circuits_dir must be a directory");
     }
-    println!("cargo:rerun-if-changed={}", circuits_dir.to_string());
+    println!("cargo:rerun-if-changed={}", circuits_dir);
 
     let witnesscalc_path = Path::new(&out_dir).join(Path::new("witnesscalc"));
     // If the witnesscalc repo is not cloned, clone it
@@ -175,7 +175,7 @@ pub fn build_and_link(circuits_dir: &str) {
         let circuit_dat_dest = witnesscalc_path.join("src").join(circuit_dat_name);
         fs::copy(&circuit_dat, &circuit_dat_dest).expect("Failed to copy circuit .dat file");
         //For each .cpp file, do the following: find the last include statement (should be #include "calcwit.hpp") and insert the following on the next line: namespace CIRCUIT_NAME {. Then, insert the closing } at the end of the file:
-        let circuit_cpp = fs::read_to_string(&path).expect("Failed to read circuit .cpp file");
+        let circuit_cpp = fs::read_to_string(path).expect("Failed to read circuit .cpp file");
         let circuit_cpp = circuit_cpp.replace(
             "#include \"calcwit.hpp\"",
             "#include \"calcwit.hpp\"\nnamespace CIRCUIT_NAME {",
@@ -264,7 +264,7 @@ fn android() {
             "Error: Source file {:?} does not exist",
             lib_path
         );
-        let dest_dir = Path::new(&output_path).join(&env::var("CARGO_NDK_ANDROID_TARGET").unwrap());
+        let dest_dir = Path::new(&output_path).join(env::var("CARGO_NDK_ANDROID_TARGET").unwrap());
         println!("cargo:rerun-if-changed={}", dest_dir.display());
         if !dest_dir.exists() {
             fs::create_dir_all(&dest_dir).unwrap();


### PR DESCRIPTION
hi! I am trying to read witness files in another project of mine ([circomkit-ffi](https://github.com/erhant/circomkit-ffi/)) and I came across your witness reader function. I have made the following changes:

- a bit of docs added / refactored
- have the witness parser take a chunk-mapper argument as well, of type `impl Fn(&[u8]) -> T`
- implement `parse_witness_to_bigints` by simply calling the generic function with chunk-mapper as `BigInt::from_le_bytes`
- use `match` instead of `if-else`; maybe opinionated but I think it looks more clear here and especially fixes the hidden case of "section 1 `pos` mutations happen within the `else` branch of `section_id == 2` check" case

with this generic function we are able to read raw witness files into other backends like:
- Arkworks: `parse_witness_to_elems(&wtns_data, F::from_le_bytes_mod_order)`
- Lambdaworks: `parse_witness_to_elems(&wtns_data, |bytes| FrElement::from_bytes_le(bytes).unwrap())`