### PR TITLE
refactor: clean up imports and remove unused Android linking code

### DIFF
--- a/witnesscalc_adapter/src/lib.rs
+++ b/witnesscalc_adapter/src/lib.rs
@@ -1,10 +1,6 @@
 pub use paste;
 pub use serde_json;
-use std::{
-    env, fs,
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::{env, fs, path::Path, process::Command};
 
 pub mod convert_type;
 pub use convert_type::*;
@@ -254,30 +250,5 @@ pub fn build_and_link(circuits_dir: &str) {
         });
         println!("cargo:rustc-link-lib=dylib=fr");
         println!("cargo:rustc-link-lib=dylib=gmp");
-    }
-
-    // refer to https://github.com/bbqsrc/cargo-ndk to see how to link the libc++_shared.so file in Android
-    if env::var("CARGO_CFG_TARGET_OS").unwrap() == "android" {
-        android();
-    }
-}
-
-fn android() {
-    println!("cargo:rustc-link-lib=c++_shared");
-
-    if let Ok(output_path) = env::var("CARGO_NDK_OUTPUT_PATH") {
-        let sysroot_libs_path = PathBuf::from(env::var_os("CARGO_NDK_SYSROOT_LIBS_PATH").unwrap());
-        let lib_path = sysroot_libs_path.join("libc++_shared.so");
-        assert!(
-            lib_path.exists(),
-            "Error: Source file {:?} does not exist",
-            lib_path
-        );
-        let dest_dir = Path::new(&output_path).join(env::var("CARGO_NDK_ANDROID_TARGET").unwrap());
-        println!("cargo:rerun-if-changed={}", dest_dir.display());
-        if !dest_dir.exists() {
-            fs::create_dir_all(&dest_dir).unwrap();
-        }
-        fs::copy(lib_path, Path::new(&dest_dir).join("libc++_shared.so")).unwrap();
     }
 }


### PR DESCRIPTION
bump [cargo-ndk](https://github.com/bbqsrc/cargo-ndk) from version 3 to version 4