### PR TITLE
ci: replace retired macos-13 to macos-15-intel

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -104,7 +104,7 @@ jobs:
             - name: Run tests
               run: cd tests && cargo test
     test-macOS-x86_64:
-        runs-on: macos-13
+        runs-on: macos-15-intel
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
         steps:
             - name: install dependencies


### PR DESCRIPTION
The macOS-13 based runner images are now retired as shown in [CI error log](https://github.com/zkmopro/witnesscalc_adapter/actions/runs/20364770894/job/59896600351). Switch to macos-15-intel as Github recommended

For more details, see https://github.com/actions/runner-images/issues/13046