### PR TITLE
fix: pre-allocate witness buffer to avoid macOS segfault/freeze

### DIFF
--- a/witnesscalc_adapter/src/lib.rs
+++ b/witnesscalc_adapter/src/lib.rs
@@ -52,29 +52,34 @@ macro_rules! witness {
                     let mut error_msg = vec![0u8; 256]; // Error message buffer
                     let error_msg_ptr = error_msg.as_mut_ptr() as *mut std::ffi::c_char;
 
-                    // Two-pass dynamic allocation:
-                    // Pass 1: Probe with small buffer to query required size
-                    let mut probe_buffer = vec![0u8; 1024]; // 1 KB probe buffer
-                    let mut wtns_size: std::ffi::c_ulong = probe_buffer.len() as std::ffi::c_ulong;
+                    // Pre-allocate from .dat size to avoid running C++ witnesscalc
+                    // twice (two-pass probe fragments the heap → macOS segfault/freeze).
+                    let initial_size = (circuit_size as usize) * 8;
+                    let mut wtns_buffer: Vec<u8> = Vec::with_capacity(initial_size);
+                    wtns_buffer.set_len(initial_size);
+                    let mut wtns_size: std::ffi::c_ulong = initial_size as std::ffi::c_ulong;
 
                     let result = [<witnesscalc_ $x>](
                         circuit_buffer,
                         circuit_size,
                         json_input.as_ptr(),
                         json_size,
-                        probe_buffer.as_mut_ptr() as *mut _,
+                        wtns_buffer.as_mut_ptr() as *mut _,
                         &mut wtns_size as *mut _,
                         error_msg_ptr,
                         error_msg.len() as std::ffi::c_ulong,
                     );
 
-                    // Pass 2: If buffer too small, allocate exact size and retry
-                    let final_buffer = if result == WITNESSCALC_ERROR_SHORT_BUFFER {
-                        // wtns_size now contains the required minimum size
+                    if result == WITNESSCALC_OK {
+                        wtns_buffer.truncate(wtns_size as usize);
+                        Ok(wtns_buffer)
+                    } else if result == WITNESSCALC_ERROR_SHORT_BUFFER {
                         let required_size = wtns_size as usize;
-                        println!("Witness requires {} bytes, allocating and retrying...", required_size);
+                        println!("Witness requires {} bytes (estimate {} too small), retrying...", required_size, initial_size);
+                        drop(wtns_buffer);
 
-                        let mut wtns_buffer = vec![0u8; required_size];
+                        let mut exact_buffer: Vec<u8> = Vec::with_capacity(required_size);
+                        exact_buffer.set_len(required_size);
                         let mut wtns_size: std::ffi::c_ulong = required_size as std::ffi::c_ulong;
 
                         let result = [<witnesscalc_ $x>](
@@ -82,7 +87,7 @@ macro_rules! witness {
                             circuit_size,
                             json_input.as_ptr(),
                             json_size,
-                            wtns_buffer.as_mut_ptr() as *mut _,
+                            exact_buffer.as_mut_ptr() as *mut _,
                             &mut wtns_size as *mut _,
                             error_msg_ptr,
                             error_msg.len() as std::ffi::c_ulong,
@@ -95,19 +100,14 @@ macro_rules! witness {
                             return Err($crate::__macro_deps::anyhow::anyhow!("Witness generation failed: {}", error_string));
                         }
 
-                        wtns_buffer[..wtns_size as usize].to_vec()
-                    } else if result == WITNESSCALC_OK {
-                        // Success on first try with probe buffer (small witness)
-                        probe_buffer[..wtns_size as usize].to_vec()
+                        exact_buffer.truncate(wtns_size as usize);
+                        Ok(exact_buffer)
                     } else {
-                        // Other error
                         let error_string = std::ffi::CStr::from_ptr(error_msg_ptr)
                             .to_string_lossy()
                             .into_owned();
-                        return Err($crate::__macro_deps::anyhow::anyhow!("Witness generation failed: {}", error_string));
-                    };
-
-                    Ok(final_buffer)
+                        Err($crate::__macro_deps::anyhow::anyhow!("Witness generation failed: {}", error_string))
+                    }
                 }
             }
         }

--- a/witnesscalc_adapter/src/lib.rs
+++ b/witnesscalc_adapter/src/lib.rs
@@ -52,8 +52,6 @@ macro_rules! witness {
                     let mut error_msg = vec![0u8; 256]; // Error message buffer
                     let error_msg_ptr = error_msg.as_mut_ptr() as *mut std::ffi::c_char;
 
-                    // Pre-allocate from .dat size to avoid running C++ witnesscalc
-                    // twice (two-pass probe fragments the heap → macOS segfault/freeze).
                     let initial_size = (circuit_size as usize) * 8;
                     let mut wtns_buffer: Vec<u8> = Vec::with_capacity(initial_size);
                     wtns_buffer.set_len(initial_size);


### PR DESCRIPTION
## Summary

- Pre-allocate witness buffer estimated from circuit `.dat` size (`circuit_size * 8`) instead of using a 1 KB probe buffer
- Eliminates the two-pass FFI approach that ran the C++ witness calculator twice for every large circuit
- Uses `Vec::with_capacity` + `set_len` to skip zero-init, and `truncate()` to avoid copying
- Falls back to exact-size retry if the estimate is ever too small

## Problem

The 1 KB probe buffer always triggered `WITNESSCALC_ERROR_SHORT_BUFFER` for real circuits (8-17 MB `.dat` files), forcing a full re-computation. On macOS, the first pass fragmented the heap, and `realloc()` in the second pass moved allocations, leaving stale interior pointers in the C++ library. This caused **non-deterministic segfaults and freezes** on macOS (Linux CI was unaffected due to different allocator behavior).